### PR TITLE
Use valid category in library.properties

### DIFF
--- a/LoRaSX1278/library.properties
+++ b/LoRaSX1278/library.properties
@@ -4,4 +4,4 @@ author=Jun huan
 maintainer=Jun huan <junhuanchen@qq.com>
 sentence=LoRa Api
 paragraph=
-category=LoRaSX1278 Input/Output
+category=Communication


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'LoRaSX1278 Input/Output' in library LoRaSX1278 is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format