### PR TITLE
Add url field to library.properties

### DIFF
--- a/LoRaSX1278/library.properties
+++ b/LoRaSX1278/library.properties
@@ -5,3 +5,4 @@ maintainer=Jun huan <junhuanchen@qq.com>
 sentence=LoRa Api
 paragraph=
 category=Communication
+url=https://github.com/junhuanchen/LoraManySlave


### PR DESCRIPTION
When the `url` field is missing from library.properties:

- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- The library's examples are not shown under the **File > Examples** menu
- Library Manager index inclusion request is blocked.

With older IDE versions:
- **Sketch > Include Library > Add .ZIP Library** fails silently.
- Compilation of any code that includes the library fails.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format